### PR TITLE
Skip format conversion

### DIFF
--- a/convert-for-composer.php
+++ b/convert-for-composer.php
@@ -40,7 +40,6 @@ class Converter
 
     protected $skipConversion =[
         self::MODULE                => [ 'app/code/Magento/SupportDebugger']
-
     ];
 
     protected $options;


### PR DESCRIPTION
Added black list to allow certain modules/files to be skipped during the composer conversion.
This is needed for the new support debugger module as we do not want to convert it to a composer module (needs to remain under app/code/Magento).